### PR TITLE
fix: Address PR review suggestions

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,7 +3,24 @@
 
 echo "Running pre-commit hooks..."
 
+# Update quote metadata
+echo "Updating quote metadata..."
+npm run update-metadata
+if [ $? -ne 0 ]; then
+  echo "Failed to update quote metadata. Please check the script."
+  exit 1
+fi
+
+# Add updated quotes.json to staging
+git add src/data/quotes.json
+if [ $? -ne 0 ]; then
+  echo "Failed to stage quotes.json. Please check git."
+  exit 1
+fi
+echo "Quote metadata updated and staged."
+
 # Run linters and formatters
+echo "Running linters and formatters..."
 npm run lint && npm run format
 
 # Check if linting and formatting were successful

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "format": "prettier --write .",
     "preview": "vite preview",
     "test": "jest",
+    "update-metadata": "node scripts/update-quote-metadata.js",
     "prepare": "husky install"
   },
   "dependencies": {

--- a/scripts/update-quote-metadata.js
+++ b/scripts/update-quote-metadata.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+
+const quotesFilePath = path.join(__dirname, '..', 'src', 'data', 'quotes.json');
+
+try {
+  // Read the quotes.json file
+  const fileContent = fs.readFileSync(quotesFilePath, 'utf8');
+  const quotesData = JSON.parse(fileContent);
+
+  // Ensure quotes and metadata exist
+  if (!quotesData.quotes || !quotesData.metadata) {
+    console.error('Error: Invalid quotes.json format. Missing "quotes" or "metadata" key.');
+    process.exit(1);
+  }
+
+  // Calculate total_quotes
+  const totalQuotes = quotesData.quotes.length;
+
+  // Generate categories
+  const categories = quotesData.quotes.reduce((acc, quote) => {
+    if (quote.category) {
+      acc[quote.category] = (acc[quote.category] || 0) + 1;
+    }
+    return acc;
+  }, {});
+
+  // Update metadata
+  quotesData.metadata.total_quotes = totalQuotes;
+  quotesData.metadata.categories = categories;
+  quotesData.metadata.last_updated = new Date().toISOString();
+
+  // Write the updated JSON back to the file
+  fs.writeFileSync(quotesFilePath, JSON.stringify(quotesData, null, 2), 'utf8');
+
+  console.log('Successfully updated quotes.json metadata.');
+  console.log(`  Total quotes: ${totalQuotes}`);
+  console.log(`  Categories: ${JSON.stringify(categories)}`);
+  console.log(`  Last updated: ${quotesData.metadata.last_updated}`);
+
+} catch (error) {
+  if (error.code === 'ENOENT') {
+    console.error(`Error: File not found at ${quotesFilePath}`);
+  } else if (error instanceof SyntaxError) {
+    console.error(`Error: Could not parse JSON in ${quotesFilePath}. Details: ${error.message}`);
+  } else {
+    console.error('An unexpected error occurred:', error);
+  }
+  process.exit(1);
+}

--- a/src/components/QuoteDisplay/QuoteDisplay.test.tsx
+++ b/src/components/QuoteDisplay/QuoteDisplay.test.tsx
@@ -217,7 +217,6 @@ describe('QuoteDisplay Component', () => {
       const okButton = screen.getByRole('button', { name: /OK/i });
       fireEvent.click(okButton);
 
-      await act(async () => { jest.advanceTimersByTime(10); }); // Allow state update
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 
@@ -228,7 +227,6 @@ describe('QuoteDisplay Component', () => {
 
       fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
 
-      await act(async () => { jest.advanceTimersByTime(10); }); // Allow state update
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 
@@ -240,7 +238,6 @@ describe('QuoteDisplay Component', () => {
       // The overlay is the dialog element itself in this implementation for click handling
       fireEvent.click(dialog);
 
-      await act(async () => { jest.advanceTimersByTime(10); });
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 

--- a/src/components/QuoteDisplay/index.tsx
+++ b/src/components/QuoteDisplay/index.tsx
@@ -37,24 +37,24 @@ const QuoteDisplay: React.FC = () => {
     }
   }, [currentQuote]);
 
-  // Effect for modal accessibility (Escape key)
+  // Combined effect for modal accessibility (Escape key) and focusing the close button
   useEffect(() => {
     const handleEsc = (event: KeyboardEvent) => {
-      if (event.key === 'Escape' && showCopyModal) {
+      if (event.key === 'Escape') { // No need to check showCopyModal here, as the listener is added/removed based on it
         setShowCopyModal(false);
       }
     };
-    window.addEventListener('keydown', handleEsc);
+
+    if (showCopyModal) {
+      window.addEventListener('keydown', handleEsc);
+      if (modalCloseButtonRef.current) {
+        modalCloseButtonRef.current.focus();
+      }
+    }
+
     return () => {
       window.removeEventListener('keydown', handleEsc);
     };
-  }, [showCopyModal]);
-
-  // Focus the close button when modal opens
-  useEffect(() => {
-    if (showCopyModal && modalCloseButtonRef.current) {
-      modalCloseButtonRef.current.focus();
-    }
   }, [showCopyModal]);
 
   const changeQuoteContent = useCallback(() => {


### PR DESCRIPTION
This commit implements changes based on the feedback from PR #10:

- Refactored `QuoteDisplay.test.tsx`:
    - Removed unnecessary `await act` calls with `jest.advanceTimersByTime` after `fireEvent` for cleaner tests, as `fireEvent` usually handles `act` wrappers.

- Refactored `QuoteDisplay/index.tsx`:
    - Consolidated two `useEffect` hooks for copy modal management into a single hook. This improves code organization and ensures the Escape key listener and focus management are handled more efficiently.

- Automated `quotes.json` metadata:
    - Created a new script `scripts/update-quote-metadata.js` to automatically calculate `total_quotes`, regenerate `categories` counts, and update `last_updated` timestamp in `src/data/quotes.json`.
    - Added an `update-metadata` script to `package.json`.
    - Integrated this script into the `.husky/pre-commit` hook to ensure metadata is automatically updated and staged before each commit, preventing stale or incorrect metadata.