### PR TITLE
Fix: Correct JSON import paths and quote metadata

### DIFF
--- a/src/data/quotes.json
+++ b/src/data/quotes.json
@@ -483,7 +483,7 @@
     }
   ],
   "metadata": {
-    "total_quotes": 125,
+    "total_quotes": 37,
     "last_updated": "2024-07-31T10:00:00Z",
     "version": "1.1",
     "categories": {

--- a/src/services/GradientService.ts
+++ b/src/services/GradientService.ts
@@ -1,5 +1,5 @@
 // src/services/GradientService.ts
-import allGradientsData from '../../data/gradients.json'; // Adjusted path
+import allGradientsData from '../data/gradients.json'; // Adjusted path
 
 export interface GradientDefinition {
   type: string;

--- a/src/services/QuoteService.ts
+++ b/src/services/QuoteService.ts
@@ -1,6 +1,6 @@
 // src/services/QuoteService.ts
 import { Quote, QuoteCategory } from '../types';
-import allQuotesData from '../../data/quotes.json'; // Adjusted path
+import allQuotesData from '../data/quotes.json'; // Adjusted path
 import { LocalStorageService } from './LocalStorageService';
 
 const VIEWED_QUOTES_KEY = 'viewedQuotes';


### PR DESCRIPTION
Incorrect import paths for quotes.json and gradients.json in QuoteService.ts and GradientService.ts respectively were causing errors that likely prevented the application from rendering, resulting in a blank home page.

This commit corrects these paths from `../../data/` to `../data/`.

Additionally, it updates `metadata.total_quotes` in `quotes.json` from 125 to 37 to accurately reflect the number of quotes present in the data file.